### PR TITLE
Add color pickers and UI improvements

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -6,6 +6,8 @@ import Link from "next/link";
 import { FaRedo, FaGithub } from "react-icons/fa";
 import { IconButton } from "@/components/ui/IconButton";
 import { OptionGroup } from "@/components/ui/OptionGroup";
+import { Color256Palette } from "@/components/ui/Color256Palette";
+import { RgbColorPicker } from "@/components/ui/RgbColorPicker";
 import { MockTerminal } from "@/components/MockTerminal";
 import {
   ANSIOptions,
@@ -39,6 +41,7 @@ export default function Home() {
   const [bgBrightColor, setBgBrightColor] = useState<string>("Default");
   const [bg256Value, setBg256Value] = useState<number>(0);
   const [bgRgb, setBgRgb] = useState({ r: 0, g: 0, b: 0 });
+  const [includeBgInCode, setIncludeBgInCode] = useState(true);
 
   const [selectedStyleCodes, setSelectedStyleCodes] = useState<ANSIStyleCode[]>(
     ["0"]
@@ -115,6 +118,7 @@ export default function Home() {
     setBgBrightColor("Default");
     setBg256Value(0);
     setBgRgb({ r: 0, g: 0, b: 0 });
+    setIncludeBgInCode(true);
     setSelectedStyleCodes(["0"]);
     setCurrentEscapeSequence("\\x1b");
   };
@@ -123,7 +127,7 @@ export default function Home() {
     const params = [
       ansiOptions.styleSgr,
       ansiOptions.foregroundSgr,
-      ansiOptions.backgroundSgr,
+      includeBgInCode ? ansiOptions.backgroundSgr : null,
     ]
       .filter((p) => p !== null && p !== undefined && p !== "")
       .join(";");
@@ -176,6 +180,40 @@ export default function Home() {
         <IconButton icon={FaRedo} text="Refresh" onClick={handleRefresh} />
       </div>
       <div className="space-y-6 w-full">
+        <div className="w-full">
+          <MockTerminal {...ansiOptions} />
+        </div>
+        <div className="p-4 bg-gray-100 dark:bg-gray-800 rounded-lg">
+          <div className="flex items-center justify-center gap-2 mb-3">
+            <span className="text-sm text-gray-500 dark:text-gray-400">Escape:</span>
+            {ESCAPE_SEQUENCE_LABELS.map((seq) => (
+              <button
+                key={seq}
+                onClick={() => setCurrentEscapeSequence(seq)}
+                className={`px-2 py-1 text-sm font-mono rounded ${
+                  currentEscapeSequence === seq
+                    ? "bg-blue-500 text-white"
+                    : "bg-gray-200 dark:bg-gray-700 hover:bg-gray-300 dark:hover:bg-gray-600"
+                }`}
+              >
+                {seq}
+              </button>
+            ))}
+          </div>
+          <div
+            className="cursor-pointer text-center"
+            onClick={handleCopy}
+          >
+            <p className="font-mono text-lg mb-2 break-all">
+              {getFullAnsiCode()}
+            </p>
+            <p className="text-sm text-gray-500 dark:text-gray-400">
+              {copied ? "Copied!" : "Click to copy"}
+            </p>
+          </div>
+        </div>
+      </div>
+      <div className="space-y-6 w-full mt-6">
         <div className="p-4 border border-gray-300 dark:border-gray-700 rounded-lg">
           <h3 className="text-lg font-semibold mb-3">Foreground Color</h3>
           <OptionGroup
@@ -201,24 +239,31 @@ export default function Home() {
             />
           )}
           {fgMode === "256" && (
-            <div className="flex items-center mt-2">
-              <label htmlFor="fg256" className="w-40 flex-shrink-0">
-                Index (0-255):
-              </label>
-              <input
-                type="number"
-                id="fg256"
-                value={fg256Value}
-                min="0"
-                max="255"
-                onChange={(e) => setFg256Value(parseInt(e.target.value, 10))}
-                className="p-2 border rounded dark:bg-gray-800 dark:border-gray-600"
+            <div className="mt-2">
+              <div className="flex items-center">
+                <label htmlFor="fg256" className="w-40 flex-shrink-0">
+                  Index (0-255):
+                </label>
+                <input
+                  type="number"
+                  id="fg256"
+                  value={fg256Value}
+                  min="0"
+                  max="255"
+                  onChange={(e) => setFg256Value(parseInt(e.target.value, 10))}
+                  className="p-2 border rounded dark:bg-gray-800 dark:border-gray-600"
+                />
+              </div>
+              <Color256Palette
+                selectedValue={fg256Value}
+                onSelect={setFg256Value}
               />
             </div>
           )}
           {fgMode === "rgb" && (
             <div className="flex items-center gap-4 mt-2 flex-wrap">
               <div className="w-40 flex-shrink-0">RGB:</div>
+              <RgbColorPicker rgb={fgRgb} onChange={setFgRgb} />
               <input
                 type="number"
                 placeholder="R"
@@ -281,24 +326,31 @@ export default function Home() {
             />
           )}
           {bgMode === "256" && (
-            <div className="flex items-center mt-2">
-              <label htmlFor="bg256" className="w-40 flex-shrink-0">
-                Index (0-255):
-              </label>
-              <input
-                type="number"
-                id="bg256"
-                value={bg256Value}
-                min="0"
-                max="255"
-                onChange={(e) => setBg256Value(parseInt(e.target.value, 10))}
-                className="p-2 border rounded dark:bg-gray-800 dark:border-gray-600"
+            <div className="mt-2">
+              <div className="flex items-center">
+                <label htmlFor="bg256" className="w-40 flex-shrink-0">
+                  Index (0-255):
+                </label>
+                <input
+                  type="number"
+                  id="bg256"
+                  value={bg256Value}
+                  min="0"
+                  max="255"
+                  onChange={(e) => setBg256Value(parseInt(e.target.value, 10))}
+                  className="p-2 border rounded dark:bg-gray-800 dark:border-gray-600"
+                />
+              </div>
+              <Color256Palette
+                selectedValue={bg256Value}
+                onSelect={setBg256Value}
               />
             </div>
           )}
           {bgMode === "rgb" && (
             <div className="flex items-center gap-4 mt-2 flex-wrap">
               <div className="w-40 flex-shrink-0">RGB:</div>
+              <RgbColorPicker rgb={bgRgb} onChange={setBgRgb} />
               <input
                 type="number"
                 placeholder="R"
@@ -334,6 +386,15 @@ export default function Home() {
               />
             </div>
           )}
+          <label className="flex items-center gap-2 mt-3 cursor-pointer">
+            <input
+              type="checkbox"
+              checked={!includeBgInCode}
+              onChange={(e) => setIncludeBgInCode(!e.target.checked)}
+              className="w-4 h-4 cursor-pointer"
+            />
+            <span className="text-sm">Do not include in code output</span>
+          </label>
         </div>
 
         <div className="p-4 border border-gray-300 dark:border-gray-700 rounded-lg">
@@ -349,34 +410,6 @@ export default function Home() {
           />
         </div>
 
-        <div className="p-4 border border-gray-300 dark:border-gray-700 rounded-lg">
-          <OptionGroup
-            label="Escape sequence:"
-            options={ESCAPE_SEQUENCE_LABELS.map((seq) => ({
-              label: seq,
-              value: seq,
-            }))}
-            selectedValue={currentEscapeSequence}
-            onUpdate={(val) =>
-              setCurrentEscapeSequence(val as ANSIEscapeSequence)
-            }
-          />
-        </div>
-
-        <div
-          className="cursor-pointer p-4 text-center bg-gray-100 dark:bg-gray-800 rounded-lg"
-          onClick={handleCopy}
-        >
-          <p className="font-mono text-lg mb-2 break-all">
-            {getFullAnsiCode()}
-          </p>
-          <p className="text-sm text-gray-500 dark:text-gray-400">
-            {copied ? "Copied!" : "Click to copy"}
-          </p>
-        </div>
-        <div className="pb-8 w-full">
-          <MockTerminal {...ansiOptions} />
-        </div>
       </div>
       <Link
         href="https://github.com/jamisonrobey/ansi-generator"

--- a/components/ui/Color256Palette.tsx
+++ b/components/ui/Color256Palette.tsx
@@ -1,0 +1,74 @@
+import { get256ColorCss } from "@/lib/ansiTypes";
+
+interface Color256PaletteProps {
+  selectedValue: number;
+  onSelect: (value: number) => void;
+}
+
+export function Color256Palette({
+  selectedValue,
+  onSelect,
+}: Color256PaletteProps) {
+  // Generate all 256 colors
+  const colors = Array.from({ length: 256 }, (_, i) => i);
+
+  // Split into sections for better layout
+  const standardColors = colors.slice(0, 16); // 0-15: standard + bright
+  const cubeColors = colors.slice(16, 232); // 16-231: 6x6x6 color cube
+  const grayscaleColors = colors.slice(232, 256); // 232-255: grayscale
+
+  return (
+    <div className="mt-2 space-y-2">
+      {/* Standard and bright colors (2 rows of 8) */}
+      <div className="grid grid-cols-8 gap-1">
+        {standardColors.map((code) => (
+          <button
+            key={code}
+            onClick={() => onSelect(code)}
+            className={`w-6 h-6 rounded border-2 transition-transform hover:scale-110 ${
+              selectedValue === code
+                ? "border-blue-500 ring-2 ring-blue-300"
+                : "border-gray-400 dark:border-gray-600"
+            }`}
+            style={{ backgroundColor: get256ColorCss(code) }}
+            title={`Color ${code}`}
+          />
+        ))}
+      </div>
+
+      {/* 6x6x6 color cube (6 rows of 36) */}
+      <div className="grid grid-cols-18 gap-0.5" style={{ gridTemplateColumns: "repeat(36, 1fr)" }}>
+        {cubeColors.map((code) => (
+          <button
+            key={code}
+            onClick={() => onSelect(code)}
+            className={`w-4 h-4 rounded-sm border transition-transform hover:scale-125 hover:z-10 ${
+              selectedValue === code
+                ? "border-blue-500 ring-1 ring-blue-300"
+                : "border-transparent"
+            }`}
+            style={{ backgroundColor: get256ColorCss(code) }}
+            title={`Color ${code}`}
+          />
+        ))}
+      </div>
+
+      {/* Grayscale (1 row of 24) */}
+      <div className="grid grid-cols-12 gap-1">
+        {grayscaleColors.map((code) => (
+          <button
+            key={code}
+            onClick={() => onSelect(code)}
+            className={`w-5 h-5 rounded border-2 transition-transform hover:scale-110 ${
+              selectedValue === code
+                ? "border-blue-500 ring-2 ring-blue-300"
+                : "border-gray-400 dark:border-gray-600"
+            }`}
+            style={{ backgroundColor: get256ColorCss(code) }}
+            title={`Color ${code}`}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/components/ui/RgbColorPicker.tsx
+++ b/components/ui/RgbColorPicker.tsx
@@ -1,0 +1,38 @@
+interface RgbColorPickerProps {
+  rgb: { r: number; g: number; b: number };
+  onChange: (rgb: { r: number; g: number; b: number }) => void;
+}
+
+function rgbToHex(r: number, g: number, b: number): string {
+  const toHex = (n: number) => n.toString(16).padStart(2, "0");
+  return `#${toHex(r)}${toHex(g)}${toHex(b)}`;
+}
+
+function hexToRgb(hex: string): { r: number; g: number; b: number } {
+  const result = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex);
+  return result
+    ? {
+        r: parseInt(result[1], 16),
+        g: parseInt(result[2], 16),
+        b: parseInt(result[3], 16),
+      }
+    : { r: 0, g: 0, b: 0 };
+}
+
+export function RgbColorPicker({ rgb, onChange }: RgbColorPickerProps) {
+  const hexValue = rgbToHex(rgb.r, rgb.g, rgb.b);
+
+  const handleColorChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    onChange(hexToRgb(e.target.value));
+  };
+
+  return (
+    <input
+      type="color"
+      value={hexValue}
+      onChange={handleColorChange}
+      className="w-10 h-10 rounded cursor-pointer border border-gray-300 dark:border-gray-600"
+      title="Pick a color"
+    />
+  );
+}

--- a/lib/ansiTypes.ts
+++ b/lib/ansiTypes.ts
@@ -147,7 +147,7 @@ const colorCssMap: Record<string, string> = {
   "107": "white",
 };
 
-function get256ColorCss(code: number): string {
+export function get256ColorCss(code: number): string {
   if (code >= 0 && code <= 7) return colorCssMap[(code + 30).toString()]; // standard colors
   if (code >= 8 && code <= 15) return colorCssMap[(code - 8 + 90).toString()]; // bright colors
   if (code >= 16 && code <= 231) {


### PR DESCRIPTION
Hey!

Disclosure: I'm not familiar with frontend coding and used Claude Code to create this PR. Feel free to reject it straight away - no hard feelings! I just made these changes to make my life easier when setting up console output.

**New Features:**
- Visual 256-color palette - Click to select any of the 256 ANSI colors
- RGB color picker - Native color picker that syncs with the RGB inputs
- Background exclusion option - Checkbox to exclude background color from the generated code (handy for dark mode terminal users who just want to preview)

**UI Improvements:**
- Moved preview and copy panel to the top for better visibility
- Combined escape sequence selector into the copy panel for a cleaner layout